### PR TITLE
Fix relative path in import statement

### DIFF
--- a/src/area_plot/main.py
+++ b/src/area_plot/main.py
@@ -9,7 +9,7 @@
 import plotly.graph_objects as go
 import argparse
 import pandas as pd
-import utils_area as utils
+from . import utils_area as utils
 import os
 
 


### PR DESCRIPTION
Import of `area_utils` did not work when installing the module. ChatGPT fixed it with a relative import in `main.py:12`.